### PR TITLE
Remove some unneded clones (speed optimisation)

### DIFF
--- a/src/extension_towers/fp3.rs
+++ b/src/extension_towers/fp3.rs
@@ -241,17 +241,17 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp3<'a,
         s0.square();
         let mut ab = a.clone();
         ab.mul_assign(&b);
-        let mut s1 = ab.clone();
+        let mut s1 = ab;
         s1.double();
-        let mut s2 = a.clone();
+        let mut s2 = a;
         s2.sub_assign(&b);
         s2.add_assign(&c);
         s2.square();
-        let mut bc = b.clone();
+        let mut bc = b;
         bc.mul_assign(&c);
-        let mut s3 = bc.clone();
+        let mut s3 = bc;
         s3.double();
-        let mut s4 = c.clone();
+        let mut s4 = c;
         s4.square();
 
         self.c0 = s0.clone();

--- a/src/extension_towers/fp3.rs
+++ b/src/extension_towers/fp3.rs
@@ -129,19 +129,19 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp3<'a,
             let mut n5 = t5.clone();
             n5.mul_by_nonresidue(self.extension_field);
 
-            let mut s0 = t0.clone();
+            let mut s0 = t0;
             s0.sub_assign(&n5);
-            let mut s1 = t2.clone();
+            let mut s1 = t2;
             s1.mul_by_nonresidue(self.extension_field);
             s1.sub_assign(&t3);
-            let mut s2 = t1.clone();
+            let mut s2 = t1;
             s2.sub_assign(&t4); // typo in paper referenced above. should be "-" as per Scott, but is "*"
 
             let mut a1 = self.c2.clone();
             a1.mul_assign(&s1);
             let mut a2 = self.c1.clone();
             a2.mul_assign(&s2);
-            let mut a3 = a1.clone();
+            let mut a3 = a1;
             a3.add_assign(&a2);
             a3.mul_by_nonresidue(self.extension_field);
             let mut t6 = self.c0.clone();
@@ -158,7 +158,7 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp3<'a,
             c0.mul_assign(&s0);
             let mut c1 = t6.clone();
             c1.mul_assign(&s1);
-            let mut c2 = t6.clone();
+            let mut c2 = t6;
             c2.mul_assign(&s2);
 
 

--- a/src/extension_towers/fp3.rs
+++ b/src/extension_towers/fp3.rs
@@ -206,17 +206,17 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp3<'a,
         y.sub_assign(&ad);
         y.sub_assign(&be);
 
-        let mut t0 = a.clone();
+        let mut t0 = a;
         t0.add_assign(&c);
 
-        let mut z = d.clone();
+        let mut z = d;
         z.add_assign(&f);
         z.mul_assign(&t0);
         z.sub_assign(&ad);
         z.add_assign(&be);
         z.sub_assign(&cf);
 
-        let mut t0 = x.clone();
+        let mut t0 = x;
         t0.mul_by_nonresidue(self.extension_field);
 
         self.c0 = t0;

--- a/src/field.rs
+++ b/src/field.rs
@@ -99,9 +99,9 @@ pub trait SizedPrimeField: Sized + Send + Sync + std::fmt::Debug
 
     fn mont_power(&self) -> u64;
     fn modulus_bits(&self) -> u64;
-    fn modulus(&self) -> Self::Repr;
-    fn mont_r(&self) -> Self::Repr;
-    fn mont_r2(&self) -> Self::Repr;
+    fn modulus(&self) -> &Self::Repr;
+    fn mont_r(&self) -> &Self::Repr;
+    fn mont_r2(&self) -> &Self::Repr;
     fn mont_inv(&self) -> u64;
     fn is_valid_repr(&self, repr: Self::Repr) -> bool;
 }
@@ -126,13 +126,13 @@ impl<E: ElementRepr> SizedPrimeField for PrimeField<E> {
     fn modulus_bits(&self) -> u64 { self.modulus_bits }
 
     #[inline(always)]
-    fn modulus(&self) -> Self::Repr { self.modulus }
+    fn modulus(&self) -> &Self::Repr { &self.modulus }
 
     #[inline(always)]
-    fn mont_r(&self) -> Self::Repr { self.mont_r }
+    fn mont_r(&self) -> &Self::Repr { &self.mont_r }
 
     #[inline(always)]
-    fn mont_r2(&self) -> Self::Repr { self.mont_r2 }
+    fn mont_r2(&self) -> &Self::Repr { &self.mont_r2 }
 
     #[inline(always)]
     fn mont_inv(&self) -> u64 { self.mont_inv }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -100,7 +100,7 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > Fp<'a, E, F> {
     pub fn one(field: &'a F) -> Self {
         Self {
             field: field,
-            repr: field.mont_r()
+            repr: field.mont_r().clone()
         }
     }
 
@@ -113,7 +113,7 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > Fp<'a, E, F> {
 
             let r2 = Self {
                 field: field,
-                repr: field.mont_r2()
+                repr: field.mont_r2().clone()
             };
 
             r.mul_assign(&r2);
@@ -194,7 +194,7 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp<'a, 
     #[inline]
     fn negate(&mut self) {
         if !self.is_zero() {
-            let mut tmp = self.field.modulus();
+            let mut tmp = self.field.modulus().clone();
             tmp.sub_noborrow(&self.repr);
             self.repr = tmp;
         }
@@ -212,10 +212,10 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> > FieldElement for Fp<'a, 
 
             let modulus = self.field.modulus();
             let mut u = self.repr;
-            let mut v = modulus;
+            let mut v = modulus.clone();
             let mut b = Self {
                 field: &self.field,
-                repr: self.field.mont_r2()
+                repr: self.field.mont_r2().clone()
             }; // Avoids unnecessary reduction step.
             let mut c = Self::zero(&self.field);
 

--- a/src/mont_inverse.rs
+++ b/src/mont_inverse.rs
@@ -11,7 +11,7 @@ impl<'a, E: ElementRepr, F: SizedPrimeField<Repr = E> >Fp<'a, E, F> {
             // The Montgomery Modular Inverse - Revisited
 
             // Phase 1
-            let modulus = self.field.modulus();
+            let modulus = self.field.modulus().clone();
             let mut u = modulus;
             let mut v = self.repr;
             let mut r = F::Repr::from(0);


### PR DESCRIPTION
These changes provided a reduction of time taken by memcpy from ~25% to ~15% of the total time (when compiled to webassembly). Haven't benchmarked if this gives any speed benefit on x86_64.

Created the PR here to judge the direction and whether such changes would be accepted upstream.