### PR TITLE
Use libc c_char strings to unblock builds for Arm64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = {version = "1.0", optional = true }
 once_cell = {version = "1.*", optional = true }
 num-bigint = {version = "0.2", optional = true }
 num-traits = {version = "0.2", optional = true }
+libc = "0.2"
 
 [dev-dependencies]
 num-bigint = "0.2"

--- a/src/public_interface/eip196/c_api.rs
+++ b/src/public_interface/eip196/c_api.rs
@@ -55,7 +55,7 @@ pub extern "C" fn eip196_perform_operation(
     use std::io::Write;
 
     let op_u8: u8 = unsafe { std::mem::transmute(op) };
-    let err_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(err, EIP196_PREALLOCATE_FOR_ERROR_BYTES) };
+    let err_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(err, EIP196_PREALLOCATE_FOR_ERROR_BYTES) };
     let mut err_out: &mut [u8] = unsafe { std::mem::transmute(err_out_i8) };
 
     let operation = Eip196OperationType::from_u8(op_u8);
@@ -73,10 +73,10 @@ pub extern "C" fn eip196_perform_operation(
 
     let operation = operation.expect("is some");
     
-    let input_i8: & [i8] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
+    let input_i8: & [libc::c_char] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
     let input: &[u8] = unsafe { std::mem::transmute(input_i8) };
 
-    let raw_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(o, EIP196_PREALLOCATE_FOR_RESULT_BYTES) };
+    let raw_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(o, EIP196_PREALLOCATE_FOR_RESULT_BYTES) };
     let mut raw_out: &mut [u8] = unsafe { std::mem::transmute(raw_out_i8) };
 
     let result = match operation {

--- a/src/public_interface/eip2537/c_api.rs
+++ b/src/public_interface/eip2537/c_api.rs
@@ -87,7 +87,7 @@ pub extern "C" fn eip2537_perform_operation(
     use std::io::Write;
 
     let op_u8: u8 = unsafe { std::mem::transmute(op) };
-    let err_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(err, EIP2537_PREALLOCATE_FOR_ERROR_BYTES) };
+    let err_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(err, EIP2537_PREALLOCATE_FOR_ERROR_BYTES) };
     let mut err_out: &mut [u8] = unsafe { std::mem::transmute(err_out_i8) };
 
     let operation = Eip2537OperationType::from_u8(op_u8);
@@ -105,10 +105,10 @@ pub extern "C" fn eip2537_perform_operation(
 
     let operation = operation.expect("is some");
     
-    let input_i8: & [i8] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
+    let input_i8: & [libc::c_char] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
     let input: &[u8] = unsafe { std::mem::transmute(input_i8) };
 
-    let raw_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(o, EIP2537_PREALLOCATE_FOR_RESULT_BYTES) };
+    let raw_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(o, EIP2537_PREALLOCATE_FOR_RESULT_BYTES) };
     let mut raw_out: &mut [u8] = unsafe { std::mem::transmute(raw_out_i8) };
 
     let result = match operation {

--- a/src/public_interface/eip2539/c_api.rs
+++ b/src/public_interface/eip2539/c_api.rs
@@ -87,7 +87,7 @@ pub extern "C" fn eip2539_perform_operation(
     use std::io::Write;
 
     let op_u8: u8 = unsafe { std::mem::transmute(op) };
-    let err_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(err, EIP2539_PREALLOCATE_FOR_ERROR_BYTES) };
+    let err_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(err, EIP2539_PREALLOCATE_FOR_ERROR_BYTES) };
     let mut err_out: &mut [u8] = unsafe { std::mem::transmute(err_out_i8) };
 
     let operation = Eip2537OperationType::from_u8(op_u8);
@@ -105,10 +105,10 @@ pub extern "C" fn eip2539_perform_operation(
 
     let operation = operation.expect("is some");
     
-    let input_i8: & [i8] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
+    let input_i8: & [libc::c_char] = unsafe { std::slice::from_raw_parts(i, i_len as usize) };
     let input: &[u8] = unsafe { std::mem::transmute(input_i8) };
 
-    let raw_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(o, EIP2539_PREALLOCATE_FOR_RESULT_BYTES) };
+    let raw_out_i8: &mut [libc::c_char] = unsafe { std::slice::from_raw_parts_mut(o, EIP2539_PREALLOCATE_FOR_RESULT_BYTES) };
     let mut raw_out: &mut [u8] = unsafe { std::mem::transmute(raw_out_i8) };
 
     let result = match operation {


### PR DESCRIPTION
Use libc c_char references to defer to the platform char implementation rather than using signed char (i8).  

This allows us to build on Arm64 platforms where char is unsigned.  

ref: 

https://stackoverflow.com/questions/47684111/make-string-type-compatible-with-arm/47684200
https://users.rust-lang.org/t/expected-const-i8-found-const-u8-for-c-function-pointer-waiting-for-a-const-char/2441
https://github.com/remacs/remacs/issues/1393
etc.

Otherwise arm64 gets build errors such as:

```
...
error[E0308]: mismatched types
  --> src/public_interface/eip196/c_api.rs:58:73
   |
58 |     let err_out_i8: &mut [i8] = unsafe { std::slice::from_raw_parts_mut(err, EIP196_PREALLOCATE_FOR_ERROR_BYTES) };
   |                                                                         ^^^ expected `i8`, found `u8`
   |
   = note: expected raw pointer `*mut i8`
              found raw pointer `*mut u8`

              ...
```

Built and tested on Arm64 linux and x86_64 linux